### PR TITLE
Updated helm chart version for cluster autoscaler and node termination handler to latest.

### DIFF
--- a/modules/terraform-aws-eks-cluster-autoscaler/_variables.tf
+++ b/modules/terraform-aws-eks-cluster-autoscaler/_variables.tf
@@ -50,7 +50,7 @@ variable "fullname_override" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "9.9.2"
+  default     = "9.29.1"
   description = "Cluster Autoscaler Helm chart version."
 }
 

--- a/modules/terraform-aws-eks-node-termination-handler/_variables.tf
+++ b/modules/terraform-aws-eks-node-termination-handler/_variables.tf
@@ -24,7 +24,7 @@ variable "helm_chart_repo" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "0.15.0"
+  default     = "0.21.0"
   description = "Spot termination handler Helm chart version."
 }
 


### PR DESCRIPTION
Two changes are made-

terraform-aws-eks/modules/terraform-aws-eks-cluster-autoscaler/_variables.tf - Updated helm chart version to latest version i.e 9.29.1
terraform-aws-eks/modules/terraform-aws-eks-node-termination-handler/_variables.tf - Updated helm chart version to latest version i.e 0.21.0